### PR TITLE
Fix crash in dispather after 1 to 10 hours of running due to BOHB tuner

### DIFF
--- a/nni/algorithms/hpo/bohb_advisor/config_generator.py
+++ b/nni/algorithms/hpo/bohb_advisor/config_generator.py
@@ -315,8 +315,8 @@ class CG_BOHB:
         # Refit KDE for the current budget
         idx = np.argsort(train_losses)
 
-        train_data_good = self.impute_conditional_data(train_configs[idx[:n_good]])  # Indexes 0 to n_good-1.
-        train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:]])   # Indexes n_good to end.
+        train_data_good = self.impute_conditional_data(train_configs[idx[:n_good]])  # Indexes 0 to n_good-1 (i.e. good).
+        train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:]])   # Indexes n_good to end (i.e. bad).
 
         if train_data_good.shape[0] <= train_data_good.shape[1]:
             return

--- a/nni/algorithms/hpo/bohb_advisor/config_generator.py
+++ b/nni/algorithms/hpo/bohb_advisor/config_generator.py
@@ -315,8 +315,8 @@ class CG_BOHB:
         # Refit KDE for the current budget
         idx = np.argsort(train_losses)
 
-        train_data_good = self.impute_conditional_data(train_configs[idx[:n_good]])
-        train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:n_good+n_bad]])
+        train_data_good = self.impute_conditional_data(train_configs[idx[:n_good]])  # Window 0 to n_good
+        train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:]])   # Window n_good to end.
 
         if train_data_good.shape[0] <= train_data_good.shape[1]:
             return

--- a/nni/algorithms/hpo/bohb_advisor/config_generator.py
+++ b/nni/algorithms/hpo/bohb_advisor/config_generator.py
@@ -315,8 +315,8 @@ class CG_BOHB:
         # Refit KDE for the current budget
         idx = np.argsort(train_losses)
 
-        train_data_good = self.impute_conditional_data(train_configs[idx[:n_good]])  # Window 0 to n_good
-        train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:]])   # Window n_good to end.
+        train_data_good = self.impute_conditional_data(train_configs[idx[:n_good]])  # Indexes 0 to n_good-1.
+        train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:]])   # Indexes n_good to end.
 
         if train_data_good.shape[0] <= train_data_good.shape[1]:
             return


### PR DESCRIPTION
## Issue

The BOHB tuner will eventually crash after 1 and 10 hours of operation with an exception.

When this crash occurs:
* No more jobs are processed by the dispatcher;
* Progress halts until NNI is stopped/resumed on the command line.

See exception below. The problem is that in rare circumstances, `n_good+n_bad` is one beyond the end of the array which crashes the dispatcher with this error:

```
IndexError: index 181 is out of bounds for axis 0 with size 181
```

A clean and elegant fix is to remove `n_good+n_bad` so it slices to the end of the array by default, but no further.

## Exception

Stack trace of error:
```
[2021-01-29 17:03:47] ERROR (nni.runtime.msg_dispatcher_base/Thread-27) index 180 is out of bounds for axis 0 with size 180
Traceback (most recent call last):
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 121, in process_command_thread
    self.process_command(command, data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 147, in process_command
    command_handlers[command](data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\bohb_advisor.py", line 622, in handle_report_metric_data
    self.cg.new_result(loss=reward, budget=data['sequence'], parameters=_parameters, update_model=True)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\config_generator.py", line 319, in new_result
    train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:n_good+n_bad]])
IndexError: index 180 is out of bounds for axis 0 with size 180
[2021-01-29 17:03:47] ERROR (nni.runtime.msg_dispatcher_base/Thread-21) index 181 is out of bounds for axis 0 with size 181
Traceback (most recent call last):
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 121, in process_command_thread
    self.process_command(command, data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 147, in process_command
    command_handlers[command](data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\bohb_advisor.py", line 622, in handle_report_metric_data
    self.cg.new_result(loss=reward, budget=data['sequence'], parameters=_parameters, update_model=True)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\config_generator.py", line 319, in new_result
    train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:n_good+n_bad]])
IndexError: index 181 is out of bounds for axis 0 with size 181
```
